### PR TITLE
[변성진] todoContent 관련 서비스 추가, mongodb이름 및 uri 변경

### DIFF
--- a/src/main/kotlin/com/sixteen/todo/controller/TodoContentController.kt
+++ b/src/main/kotlin/com/sixteen/todo/controller/TodoContentController.kt
@@ -1,0 +1,4 @@
+package com.sixteen.todo.controller
+
+class TodoContentController {
+}

--- a/src/main/kotlin/com/sixteen/todo/domain/CommonMetaData.kt
+++ b/src/main/kotlin/com/sixteen/todo/domain/CommonMetaData.kt
@@ -1,0 +1,10 @@
+package com.sixteen.todo.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+
+data class CommonMetaData(
+        val createdDate: CreatedDate,
+        val updatedDate: LastModifiedDate,
+        val status: String // soft delete 위함, "N" (Normal) or "D" (Deleted)
+)

--- a/src/main/kotlin/com/sixteen/todo/domain/TodoContent.kt
+++ b/src/main/kotlin/com/sixteen/todo/domain/TodoContent.kt
@@ -1,0 +1,4 @@
+package com.sixteen.todo.domain
+
+class TodoContent {
+}

--- a/src/main/kotlin/com/sixteen/todo/repository/TodoContentRepository.kt
+++ b/src/main/kotlin/com/sixteen/todo/repository/TodoContentRepository.kt
@@ -1,0 +1,9 @@
+package com.sixteen.todo.repository
+
+import com.sixteen.todo.domain.TodoContent
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TodoRepository : MongoRepository<TodoContent, String> {
+}

--- a/src/main/kotlin/com/sixteen/todo/service/TodoContentService.kt
+++ b/src/main/kotlin/com/sixteen/todo/service/TodoContentService.kt
@@ -1,0 +1,4 @@
+package com.sixteen.todo.service
+
+class TodoContentService {
+}

--- a/src/main/kotlin/com/sixteen/todo/service/TodoContentServiceImpl.kt
+++ b/src/main/kotlin/com/sixteen/todo/service/TodoContentServiceImpl.kt
@@ -1,0 +1,23 @@
+package com.sixteen.todo.service
+
+import com.sixteen.todo.domain.TodoContent
+
+interface TodoContentService {
+    fun addTodoContent(todoContent: TodoContent): TodoContent
+
+    fun updateTodoContent(todoContent: TodoContent): TodoContent?
+
+    fun deleteById(id: String): TodoContent?
+
+    /**
+     * 모두 updateTodoContent로 순서를 바꿔도 되지만, 순서바꾸기 위해 Todo 전부 보내는건 안좋다.
+     * id와 sortOrder만으로 변경하게 한다.
+     */
+    fun modifyTodoContentSortOrder(id: String, sortOrder: Int): TodoContent?
+
+
+    /**
+     * 다수 TodoContent의 순서를 바꾸기 위함
+     */
+    fun modifyTodoContentsSortOrder(todoContentIdWithSortOrder: Map<String, Int>): Int
+}

--- a/src/test/kotlin/com/sixteen/todo/service/TodoContentServiceImplIntegrationTest.kt
+++ b/src/test/kotlin/com/sixteen/todo/service/TodoContentServiceImplIntegrationTest.kt
@@ -1,0 +1,5 @@
+package com.sixteen.todo.service
+
+internal class TodoContentServiceImplTest {
+    private
+}

--- a/src/test/kotlin/com/sixteen/todo/service/TodoContentServiceImplTest.kt
+++ b/src/test/kotlin/com/sixteen/todo/service/TodoContentServiceImplTest.kt
@@ -1,0 +1,4 @@
+package com.sixteen.todo.service
+
+class TodoContentServiceImplTest {
+}


### PR DESCRIPTION
1. mongodb atlas db추가 
- public IP 등록되야 사용가능하니까 알려주면 추가하겠음

2. mongodb 사용DB변경 
- TodoListDB 라는 DB를 사용하는 것으로 해서, (이름을 최대한 늘려서) 나중에 혼동하지 않도록 (이름이 길수록 덜헷갈림) 
- 이름은 대충지어서 피드백필요 ( 다른 긴 이름 ) 

3. [todo/issues#1](https://github.com/three-hundred/todo/issues/1) 내용 진행 - todoContents save까지

Mongo Audit 기능을 활용해서 update시에 계속 날짜바뀌도록 함.